### PR TITLE
Update calib_dlg.cpp

### DIFF
--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -227,6 +227,7 @@ enum FILAMENT_TYPE : int
     tPLA = 0,
     tABS_ASA,
     tPETG,
+    tPCTG,
     tTPU,
     tPA_CF,
     tPET_CF,
@@ -383,6 +384,10 @@ void Temp_Calibration_Dlg::on_filament_type_changed(wxCommandEvent& event) {
         case tPETG:
             start = 250;
             end = 230;
+            break;
+	case tPCTG:
+            start = 240;
+            end = 280;
             break;
         case tTPU:
             start = 240;


### PR DESCRIPTION
Added values for missing PCTG temperature range. Fixes bug #7323 which caused subsiquent values to not be correct.

# Description

When using temperature calibration, values for TPU, PA-CF, PET-CF and Custom were incorrect because the cherrypicked PCTG change from Bambu Studio was missing the values too.

I'll contribute this fix back to github/BambuLab too

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
